### PR TITLE
Refactor CLI entrypoint and expand test coverage

### DIFF
--- a/cmd/promptext/main_test.go
+++ b/cmd/promptext/main_test.go
@@ -1,128 +1,290 @@
 package main
 
 import (
-	"os"
+	"bytes"
+	"errors"
+	"sync"
 	"testing"
-
-	"github.com/spf13/pflag"
 )
 
-func TestMainFlags(t *testing.T) {
-	// Save original os.Args and pflag.CommandLine
-	oldArgs := os.Args
-	oldFlagCommandLine := pflag.CommandLine
-	defer func() {
-		// Restore original values after test
-		os.Args = oldArgs
-		pflag.CommandLine = oldFlagCommandLine
-	}()
+type fakeInitializer struct {
+	runErr error
+	called bool
+}
 
-	tests := []struct {
-		name     string
-		args     []string
-		expected struct {
-			dir      string
-			ext      string
-			exclude  string
-			infoOnly bool
-			verbose  bool
-			format   string
-			outFile  string
-		}
-	}{
-		{
-			name: "default values",
-			args: []string{"promptext"},
-			expected: struct {
-				dir      string
-				ext      string
-				exclude  string
-				infoOnly bool
-				verbose  bool
-				format   string
-				outFile  string
-			}{
-				dir:      ".",
-				ext:      "",
-				exclude:  "",
-				infoOnly: false,
-				verbose:  false,
-				format:   "markdown",
-				outFile:  "",
-			},
+func (f *fakeInitializer) Run() error {
+	f.called = true
+	return f.runErr
+}
+
+func newTestDeps() (cliDeps, *bytes.Buffer, *bytes.Buffer) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	deps := cliDeps{
+		stdout: stdout,
+		stderr: stderr,
+		usage:  func() {},
+		checkForUpdate: func(string) (bool, string, error) {
+			return false, "", nil
 		},
-		{
-			name: "all flags set",
-			args: []string{
-				"promptext",
-				"--directory", "/test/path",
-				"--extension", ".go,.js",
-				"--exclude", "vendor,node_modules",
-				"--info",
-				"--verbose",
-				"--format", "xml",
-				"--output", "output.xml",
-			},
-			expected: struct {
-				dir      string
-				ext      string
-				exclude  string
-				infoOnly bool
-				verbose  bool
-				format   string
-				outFile  string
-			}{
-				dir:      "/test/path",
-				ext:      ".go,.js",
-				exclude:  "vendor,node_modules",
-				infoOnly: true,
-				verbose:  true,
-				format:   "xml",
-				outFile:  "output.xml",
-			},
+		updater: func(string, bool) error {
+			return nil
+		},
+		notifyUpdate: func(string) {},
+		processorRun: func(string, string, string, bool, bool, bool, string, string, bool, bool, bool, bool, bool, string, int, bool) error {
+			return nil
+		},
+		absPath: func(p string) (string, error) {
+			return "/abs/" + p, nil
 		},
 	}
+	return deps, stdout, stderr
+}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Reset pflag.CommandLine for each test
-			pflag.CommandLine = pflag.NewFlagSet(tt.args[0], pflag.ExitOnError)
-			os.Args = tt.args
+func TestRunHelp(t *testing.T) {
+	deps, _, _ := newTestDeps()
+	usageCalled := 0
+	deps.usage = func() {
+		usageCalled++
+	}
+	deps.processorRun = func(string, string, string, bool, bool, bool, string, string, bool, bool, bool, bool, bool, string, int, bool) error {
+		t.Fatalf("processor should not run when showing help")
+		return nil
+	}
 
-			// Define flags again (since we're using a new FlagSet)
-			dirPath := pflag.StringP("directory", "d", ".", "Directory path to process")
-			extension := pflag.StringP("extension", "e", "", "File extension to filter, e.g., .go,.js")
-			exclude := pflag.StringP("exclude", "x", "", "Patterns to exclude, comma-separated")
-			infoOnly := pflag.BoolP("info", "i", false, "Only display project summary")
-			verbose := pflag.BoolP("verbose", "v", false, "Show full code content in terminal")
-			format := pflag.StringP("format", "f", "markdown", "Output format: markdown, xml, json")
-			outFile := pflag.StringP("output", "o", "", "Output file path")
+	if code := run([]string{"--help"}, deps); code != 0 {
+		t.Fatalf("expected exit code 0, got %d", code)
+	}
+	if usageCalled != 1 {
+		t.Fatalf("expected usage to be called once, got %d", usageCalled)
+	}
+}
 
-			// Parse flags
-			pflag.Parse()
+func TestRunVersion(t *testing.T) {
+	deps, stdout, _ := newTestDeps()
+	deps.notifyUpdate = nil
+	originalVersion, originalDate := version, date
+	version = "test-version"
+	date = "2024-01-01"
+	t.Cleanup(func() {
+		version = originalVersion
+		date = originalDate
+	})
 
-			// Check if parsed values match expected values
-			if *dirPath != tt.expected.dir {
-				t.Errorf("dirPath = %v, want %v", *dirPath, tt.expected.dir)
-			}
-			if *extension != tt.expected.ext {
-				t.Errorf("extension = %v, want %v", *extension, tt.expected.ext)
-			}
-			if *exclude != tt.expected.exclude {
-				t.Errorf("exclude = %v, want %v", *exclude, tt.expected.exclude)
-			}
-			if *infoOnly != tt.expected.infoOnly {
-				t.Errorf("infoOnly = %v, want %v", *infoOnly, tt.expected.infoOnly)
-			}
-			if *verbose != tt.expected.verbose {
-				t.Errorf("verbose = %v, want %v", *verbose, tt.expected.verbose)
-			}
-			if *format != tt.expected.format {
-				t.Errorf("format = %v, want %v", *format, tt.expected.format)
-			}
-			if *outFile != tt.expected.outFile {
-				t.Errorf("outFile = %v, want %v", *outFile, tt.expected.outFile)
-			}
-		})
+	if code := run([]string{"--version"}, deps); code != 0 {
+		t.Fatalf("expected exit code 0, got %d", code)
+	}
+	if got := stdout.String(); got != "promptext version test-version (2024-01-01)\n" {
+		t.Fatalf("unexpected version output: %q", got)
+	}
+}
+
+func TestRunCheckUpdateSuccess(t *testing.T) {
+	deps, stdout, _ := newTestDeps()
+	deps.notifyUpdate = nil
+	deps.checkForUpdate = func(current string) (bool, string, error) {
+		if current != version {
+			t.Fatalf("unexpected version: %s", current)
+		}
+		return true, "v2.0.0", nil
+	}
+
+	if code := run([]string{"--check-update"}, deps); code != 0 {
+		t.Fatalf("expected exit code 0, got %d", code)
+	}
+	if got := stdout.String(); got != "A new version is available: v2.0.0 (current: dev)\nRun 'promptext --update' to update to the latest version\n" {
+		t.Fatalf("unexpected stdout: %q", got)
+	}
+}
+
+func TestRunCheckUpdateError(t *testing.T) {
+	deps, _, stderr := newTestDeps()
+	deps.notifyUpdate = nil
+	deps.checkForUpdate = func(string) (bool, string, error) {
+		return false, "", errors.New("boom")
+	}
+
+	if code := run([]string{"--check-update"}, deps); code != 1 {
+		t.Fatalf("expected exit code 1, got %d", code)
+	}
+	if got := stderr.String(); got != "Error checking for updates: boom\n" {
+		t.Fatalf("unexpected stderr: %q", got)
+	}
+}
+
+func TestRunUpdateError(t *testing.T) {
+	deps, _, stderr := newTestDeps()
+	deps.notifyUpdate = nil
+	deps.updater = func(string, bool) error {
+		return errors.New("update failed")
+	}
+
+	if code := run([]string{"--update"}, deps); code != 1 {
+		t.Fatalf("expected exit code 1, got %d", code)
+	}
+	if got := stderr.String(); got != "Error updating: update failed\n" {
+		t.Fatalf("unexpected stderr: %q", got)
+	}
+}
+
+func TestRunInitSuccess(t *testing.T) {
+	deps, _, _ := newTestDeps()
+	fakeInit := &fakeInitializer{}
+	deps.newInitializer = func(root string, force bool, quiet bool) initializerRunner {
+		if root != "/abs/project" {
+			t.Fatalf("unexpected root: %s", root)
+		}
+		if !force {
+			t.Fatalf("expected force to be true")
+		}
+		if quiet {
+			t.Fatalf("expected quiet to be false")
+		}
+		return fakeInit
+	}
+
+	if code := run([]string{"--init", "--force", "-d", "project"}, deps); code != 0 {
+		t.Fatalf("expected exit code 0, got %d", code)
+	}
+	if !fakeInit.called {
+		t.Fatalf("expected initializer to be invoked")
+	}
+}
+
+func TestRunInitError(t *testing.T) {
+	deps, _, stderr := newTestDeps()
+	fakeInit := &fakeInitializer{runErr: errors.New("init failed")}
+	deps.newInitializer = func(string, bool, bool) initializerRunner {
+		return fakeInit
+	}
+
+	if code := run([]string{"--init"}, deps); code != 1 {
+		t.Fatalf("expected exit code 1, got %d", code)
+	}
+	if got := stderr.String(); got != "Error initializing config: init failed\n" {
+		t.Fatalf("unexpected stderr: %q", got)
+	}
+}
+
+func TestRunFormatWarning(t *testing.T) {
+	deps, _, stderr := newTestDeps()
+	formatArg := ""
+	deps.processorRun = func(_ string, _ string, _ string, _ bool, _ bool, _ bool, outputFormat string, _ string, _ bool, _ bool, _ bool, _ bool, _ bool, _ string, _ int, _ bool) error {
+		formatArg = outputFormat
+		return nil
+	}
+
+	if code := run([]string{"--format", "jsonl", "--output", "context.ptx"}, deps); code != 0 {
+		t.Fatalf("expected exit code 0, got %d", code)
+	}
+	if got := stderr.String(); got != "⚠️  Warning: format flag 'jsonl' conflicts with output extension '.ptx' - using 'jsonl' (flag takes precedence)\n" {
+		t.Fatalf("unexpected stderr: %q", got)
+	}
+	if formatArg != "jsonl" {
+		t.Fatalf("expected processor to receive explicit format, got %s", formatArg)
+	}
+}
+
+func TestRunFormatAutoDetection(t *testing.T) {
+	deps, _, _ := newTestDeps()
+	var formatArg string
+	deps.processorRun = func(_ string, _ string, _ string, _ bool, _ bool, _ bool, outputFormat string, _ string, _ bool, _ bool, _ bool, _ bool, _ bool, _ string, _ int, _ bool) error {
+		formatArg = outputFormat
+		return nil
+	}
+
+	if code := run([]string{"--output", "context.md"}, deps); code != 0 {
+		t.Fatalf("expected exit code 0, got %d", code)
+	}
+	if formatArg != "markdown" {
+		t.Fatalf("expected markdown format, got %s", formatArg)
+	}
+}
+
+func TestRunProcessorInvocation(t *testing.T) {
+	deps, _, _ := newTestDeps()
+	called := false
+	deps.processorRun = func(dir string, extension string, exclude string, noCopy bool, infoOnly bool, verbose bool, outputFormat string, outFile string, debug bool, gitignore bool, useDefaultRules bool, dryRun bool, quiet bool, relevance string, maxTokens int, explainSelection bool) error {
+		called = true
+		if dir != "./other" {
+			t.Fatalf("unexpected dir: %s", dir)
+		}
+		if extension != ".go" {
+			t.Fatalf("unexpected extension: %s", extension)
+		}
+		if !noCopy {
+			t.Fatalf("expected noCopy true")
+		}
+		if !infoOnly {
+			t.Fatalf("expected infoOnly true")
+		}
+		if !verbose {
+			t.Fatalf("expected verbose true")
+		}
+		if outputFormat != "ptx" {
+			t.Fatalf("unexpected format: %s", outputFormat)
+		}
+		if outFile != "out.ptx" {
+			t.Fatalf("unexpected outFile: %s", outFile)
+		}
+		if !debug {
+			t.Fatalf("expected debug true")
+		}
+		if gitignore {
+			t.Fatalf("expected gitignore false")
+		}
+		if useDefaultRules {
+			t.Fatalf("expected useDefaultRules false")
+		}
+		if !dryRun {
+			t.Fatalf("expected dryRun true")
+		}
+		if quiet {
+			t.Fatalf("expected quiet false")
+		}
+		if relevance != "foo" {
+			t.Fatalf("unexpected relevance: %s", relevance)
+		}
+		if maxTokens != 123 {
+			t.Fatalf("unexpected maxTokens: %d", maxTokens)
+		}
+		if !explainSelection {
+			t.Fatalf("expected explainSelection true")
+		}
+		return nil
+	}
+
+	args := []string{"-d", "./other", "--extension", ".go", "--exclude", "vendor", "--no-copy", "--info", "--verbose", "--output", "out.ptx", "--debug", "--gitignore=false", "--use-default-rules=false", "--dry-run", "--relevant", "foo", "--max-tokens", "123", "--explain-selection"}
+	if code := run(args, deps); code != 0 {
+		t.Fatalf("expected exit code 0, got %d", code)
+	}
+	if !called {
+		t.Fatalf("processor was not invoked")
+	}
+}
+
+func TestRunNotifiesUpdate(t *testing.T) {
+	deps, _, _ := newTestDeps()
+	var wg sync.WaitGroup
+	wg.Add(1)
+	called := 0
+	deps.notifyUpdate = func(string) {
+		called++
+		wg.Done()
+	}
+
+	if code := run([]string{"--directory", "."}, deps); code != 0 {
+		t.Fatalf("expected exit code 0, got %d", code)
+	}
+	wg.Wait()
+	if called != 1 {
+		t.Fatalf("expected notifier to be called once, got %d", called)
+	}
+}
+
+func TestRunParseError(t *testing.T) {
+	deps, _, _ := newTestDeps()
+	if code := run([]string{"--unknown"}, deps); code != 2 {
+		t.Fatalf("expected exit code 2 for parse error, got %d", code)
 	}
 }

--- a/internal/format/ptx_jsonl_test.go
+++ b/internal/format/ptx_jsonl_test.go
@@ -1,0 +1,217 @@
+package format
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestPTXFormatterFormatIncludesManifestAndStructure(t *testing.T) {
+	formatter := &PTXFormatter{}
+	project := &ProjectOutput{
+		Metadata: &Metadata{
+			Language:     "Go",
+			Version:      "1.21",
+			Dependencies: []string{"dep1", "dep2"},
+		},
+		GitInfo: &GitInfo{
+			Branch:        "main",
+			CommitHash:    "abc123",
+			CommitMessage: "fix bug",
+		},
+		Budget: &BudgetInfo{
+			MaxTokens:       8000,
+			EstimatedTokens: 6400,
+			FileTruncations: 2,
+		},
+		FilterConfig: &FilterConfig{
+			Includes: []string{"*.go"},
+			Excludes: []string{"vendor"},
+		},
+		FileStats: &FileStatistics{
+			TotalFiles:   2,
+			TotalLines:   42,
+			PackageCount: 1,
+			FilesByType: map[string]int{
+				".go": 2,
+			},
+		},
+		DirectoryTree: &DirectoryNode{
+			Name: "root",
+			Type: "dir",
+			Children: []*DirectoryNode{
+				{Name: "main.go", Type: "file"},
+				{Name: "pkg", Type: "dir", Children: []*DirectoryNode{{Name: "pkg.go", Type: "file"}}},
+			},
+		},
+		Analysis: &ProjectAnalysis{
+			EntryPoints: map[string]string{"cmd/main.go": "main"},
+			ConfigFiles: map[string]string{"config.yaml": "app config"},
+			CoreFiles:   map[string]string{"pkg/pkg.go": "core"},
+			TestFiles:   map[string]string{"pkg/pkg_test.go": "tests"},
+		},
+		Files: []FileInfo{
+			{Path: "pkg/pkg.go", Content: "package pkg\n", Tokens: 100},
+			{Path: "main.go", Content: "package main\n", Truncation: &TruncationInfo{Mode: "head", OriginalTokens: 200}},
+		},
+	}
+
+	out, err := formatter.Format(project)
+	if err != nil {
+		t.Fatalf("Format error: %v", err)
+	}
+
+	checks := []string{
+		"schema: ptx/v2.0",
+		"language: Go",
+		"dependencies[2]: dep1,dep2",
+		"branch: main",
+		"max_tokens: 8000",
+		"includes[1]: *.go",
+		"totalFiles: 2",
+		"structure:",
+		"entryPoints[1]{desc,path}:",
+		"configFiles[1]{desc,path}:",
+		"path: pkg/pkg.go",
+		"tokens: 100",
+		"mode: head",
+	}
+	for _, want := range checks {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected output to contain %q, got:\n%s", want, out)
+		}
+	}
+}
+
+func TestPTXFormatterTreeToDirectoryMap(t *testing.T) {
+	formatter := &PTXFormatter{}
+	tree := &DirectoryNode{
+		Name: "root",
+		Type: "dir",
+		Children: []*DirectoryNode{
+			{Name: "main.go", Type: "file"},
+			{Name: "pkg", Type: "dir", Children: []*DirectoryNode{{Name: "pkg.go", Type: "file"}}},
+		},
+	}
+
+	structure := formatter.treeToDirectoryMap(tree)
+	if len(structure) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(structure))
+	}
+	filesVal, ok := structure[""]
+	if !ok {
+		t.Fatalf("missing root directory entry: %#v", structure)
+	}
+	files, ok := filesVal.([]string)
+	if !ok || len(files) != 1 || files[0] != "main.go" {
+		t.Fatalf("unexpected root files: %#v", filesVal)
+	}
+	pkgVal, ok := structure["pkg"]
+	if !ok {
+		t.Fatalf("missing pkg directory entry: %#v", structure)
+	}
+	pkgFiles, ok := pkgVal.([]string)
+	if !ok || len(pkgFiles) != 1 || pkgFiles[0] != "pkg.go" {
+		t.Fatalf("unexpected pkg files: %#v", pkgVal)
+	}
+}
+
+func TestPTXFormatterMapToList(t *testing.T) {
+	formatter := &PTXFormatter{}
+	input := map[string]string{
+		"a.go": "main",
+		"b.go": "helper",
+	}
+	list := formatter.mapToList(input)
+	if len(list) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(list))
+	}
+	paths := make(map[string]bool)
+	for _, entry := range list {
+		path, _ := entry["path"].(string)
+		paths[path] = true
+	}
+	if !paths["a.go"] || !paths["b.go"] {
+		t.Fatalf("missing paths in list: %#v", paths)
+	}
+}
+
+func TestTOONStrictFormatterEscapesContent(t *testing.T) {
+	formatter := &TOONStrictFormatter{}
+	project := &ProjectOutput{
+		GitInfo: &GitInfo{CommitMessage: "line1\nline2"},
+		Files:   []FileInfo{{Path: "main.go", Content: "func main() {\n}\n"}},
+	}
+
+	out, err := formatter.Format(project)
+	if err != nil {
+		t.Fatalf("Format error: %v", err)
+	}
+	normalized := strings.ReplaceAll(out, "\n", "\\n")
+	if !strings.Contains(normalized, "line1\\\\nline2") {
+		t.Fatalf("expected escaped commit message, got %s", normalized)
+	}
+	if !strings.Contains(normalized, "func main() {\\\\n}\\\\n\",main.go") {
+		t.Fatalf("expected escaped file content, got %s", normalized)
+	}
+}
+
+func TestJSONLFormatterProducesDeterministicLines(t *testing.T) {
+	formatter := &JSONLFormatter{}
+	project := &ProjectOutput{
+		Metadata: &Metadata{Language: "Go"},
+		GitInfo:  &GitInfo{Branch: "main", CommitHash: "abc"},
+		Budget:   &BudgetInfo{MaxTokens: 5000, EstimatedTokens: 4000, FileTruncations: 1},
+		FilterConfig: &FilterConfig{
+			Includes: []string{"*.go"},
+		},
+		Files: []FileInfo{
+			{Path: "b.go", Content: "package b", Tokens: 10},
+			{Path: "a.go", Content: "package a", Truncation: &TruncationInfo{Mode: "tail", OriginalTokens: 20}},
+		},
+	}
+
+	out, err := formatter.Format(project)
+	if err != nil {
+		t.Fatalf("Format error: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != 6 {
+		t.Fatalf("expected 6 lines, got %d: %q", len(lines), lines)
+	}
+
+	typeLine := func(idx int) string {
+		var payload map[string]interface{}
+		if err := json.Unmarshal([]byte(lines[idx]), &payload); err != nil {
+			t.Fatalf("line %d not valid json: %v", idx, err)
+		}
+		t.Helper()
+		return payload["type"].(string)
+	}
+
+	if got := typeLine(0); got != "metadata" {
+		t.Fatalf("line 0 type = %s, want metadata", got)
+	}
+	if got := typeLine(1); got != "git" {
+		t.Fatalf("line 1 type = %s, want git", got)
+	}
+	if got := typeLine(2); got != "budget" {
+		t.Fatalf("line 2 type = %s, want budget", got)
+	}
+	if got := typeLine(3); got != "filters" {
+		t.Fatalf("line 3 type = %s, want filters", got)
+	}
+	if got := typeLine(4); got != "file" || !strings.Contains(lines[4], "\"path\":\"a.go\"") {
+		t.Fatalf("line 4 should be file for a.go, got %s", lines[4])
+	}
+	if !strings.Contains(lines[4], "\"truncation\"") {
+		t.Fatalf("expected truncation metadata in first file line")
+	}
+	if got := typeLine(5); got != "file" || !strings.Contains(lines[5], "\"path\":\"b.go\"") {
+		t.Fatalf("line 5 should be file for b.go, got %s", lines[5])
+	}
+	if !strings.Contains(lines[5], "\"tokens\":10") {
+		t.Fatalf("expected token count in second file line")
+	}
+}

--- a/internal/token/tiktoken.go
+++ b/internal/token/tiktoken.go
@@ -10,23 +10,29 @@ import (
 )
 
 func init() {
+	ensureCacheDir()
+}
+
+func ensureCacheDir() {
 	// Set default cache directory if TIKTOKEN_CACHE_DIR is not set
-	if os.Getenv("TIKTOKEN_CACHE_DIR") == "" {
-		homeDir, err := os.UserHomeDir()
-		if err != nil {
-			log.Debug("Warning: Could not get user home directory: %v", err)
-			return
-		}
-
-		cacheDir := filepath.Join(homeDir, ".promptext", "cache")
-		if err := os.MkdirAll(cacheDir, 0755); err != nil {
-			log.Debug("Warning: Could not create cache directory: %v", err)
-			return
-		}
-
-		os.Setenv("TIKTOKEN_CACHE_DIR", cacheDir)
-		log.Debug("Set tiktoken cache to: %s", cacheDir)
+	if os.Getenv("TIKTOKEN_CACHE_DIR") != "" {
+		return
 	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		log.Debug("Warning: Could not get user home directory: %v", err)
+		return
+	}
+
+	cacheDir := filepath.Join(homeDir, ".promptext", "cache")
+	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+		log.Debug("Warning: Could not create cache directory: %v", err)
+		return
+	}
+
+	os.Setenv("TIKTOKEN_CACHE_DIR", cacheDir)
+	log.Debug("Set tiktoken cache to: %s", cacheDir)
 }
 
 type TokenCounter struct {

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -1,508 +1,466 @@
 package update
 
 import (
-	"encoding/json"
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
-func TestParseVersion(t *testing.T) {
-	tests := []struct {
-		name    string
-		version string
-		want    [3]int
-		wantErr bool
-	}{
-		{
-			name:    "valid version",
-			version: "0.4.3",
-			want:    [3]int{0, 4, 3},
-			wantErr: false,
-		},
-		{
-			name:    "version with major",
-			version: "1.0.0",
-			want:    [3]int{1, 0, 0},
-			wantErr: false,
-		},
-		{
-			name:    "version with double digits",
-			version: "2.15.7",
-			want:    [3]int{2, 15, 7},
-			wantErr: false,
-		},
-		{
-			name:    "invalid version format",
-			version: "invalid",
-			wantErr: true,
-		},
-		{
-			name:    "incomplete version",
-			version: "1.0",
-			wantErr: true,
-		},
+func writeTarGz(t *testing.T, fileName string, data []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+	hdr := &tar.Header{
+		Name: fileName,
+		Mode: 0644,
+		Size: int64(len(data)),
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := parseVersion(tt.version)
-			if tt.wantErr {
-				assert.Error(t, err)
-				return
-			}
-			require.NoError(t, err)
-			assert.Equal(t, tt.want, got)
-		})
+	if err := tw.WriteHeader(hdr); err != nil {
+		t.Fatalf("write header: %v", err)
 	}
+	if _, err := tw.Write(data); err != nil {
+		t.Fatalf("write data: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar: %v", err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatalf("close gzip: %v", err)
+	}
+	return buf.Bytes()
 }
 
-func TestIsNewerVersion(t *testing.T) {
-	tests := []struct {
-		name    string
-		v1      string
-		v2      string
-		want    bool
-		wantErr bool
-	}{
-		{
-			name: "major version newer",
-			v1:   "1.0.0",
-			v2:   "0.9.9",
-			want: true,
-		},
-		{
-			name: "minor version newer",
-			v1:   "0.5.0",
-			v2:   "0.4.9",
-			want: true,
-		},
-		{
-			name: "patch version newer",
-			v1:   "0.4.4",
-			v2:   "0.4.3",
-			want: true,
-		},
-		{
-			name: "same version",
-			v1:   "0.4.3",
-			v2:   "0.4.3",
-			want: false,
-		},
-		{
-			name: "older major version",
-			v1:   "0.4.3",
-			v2:   "1.0.0",
-			want: false,
-		},
-		{
-			name: "older minor version",
-			v1:   "0.3.9",
-			v2:   "0.4.0",
-			want: false,
-		},
-		{
-			name: "older patch version",
-			v1:   "0.4.2",
-			v2:   "0.4.3",
-			want: false,
-		},
-		{
-			name:    "invalid v1",
-			v1:      "invalid",
-			v2:      "0.4.3",
-			wantErr: true,
-		},
-		{
-			name:    "invalid v2",
-			v1:      "0.4.3",
-			v2:      "invalid",
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := isNewerVersion(tt.v1, tt.v2)
-			if tt.wantErr {
-				assert.Error(t, err)
-				return
-			}
-			require.NoError(t, err)
-			assert.Equal(t, tt.want, got)
-		})
-	}
-}
-
-func TestGetPlatformAssetName(t *testing.T) {
-	name, err := getPlatformAssetName()
-	require.NoError(t, err)
-	assert.NotEmpty(t, name)
-
-	// Should contain "promptext_" prefix
-	assert.Contains(t, name, "promptext_")
-
-	// Should have proper extension
-	if name[len(name)-7:] != ".tar.gz" && name[len(name)-4:] != ".zip" {
-		t.Errorf("invalid extension: %s", name)
-	}
-}
-
-func TestUpdateCheckCache(t *testing.T) {
-	// Create temporary cache directory
-	tempDir := t.TempDir()
-	cachePath := filepath.Join(tempDir, "update_check.json")
-
-	// Test saving cache
-	cache := UpdateCheckCache{
-		LastCheck:       time.Now(),
-		LatestVersion:   "v0.5.0",
-		UpdateAvailable: true,
-	}
-
-	data, err := json.Marshal(cache)
-	require.NoError(t, err)
-	err = os.WriteFile(cachePath, data, 0644)
-	require.NoError(t, err)
-
-	// Test loading cache
-	loadedData, err := os.ReadFile(cachePath)
-	require.NoError(t, err)
-
-	var loadedCache UpdateCheckCache
-	err = json.Unmarshal(loadedData, &loadedCache)
-	require.NoError(t, err)
-
-	assert.Equal(t, cache.LatestVersion, loadedCache.LatestVersion)
-	assert.Equal(t, cache.UpdateAvailable, loadedCache.UpdateAvailable)
-	assert.WithinDuration(t, cache.LastCheck, loadedCache.LastCheck, time.Second)
-}
-
-func TestCheckForUpdate_DevVersion(t *testing.T) {
-	_, _, err := CheckForUpdate("dev")
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "development build")
-}
-
-func TestCheckForUpdate_UnknownVersion(t *testing.T) {
-	_, _, err := CheckForUpdate("unknown")
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "development build")
-}
-
-func TestGetCacheDir(t *testing.T) {
-	cacheDir, err := getCacheDir()
-	require.NoError(t, err)
-	assert.NotEmpty(t, cacheDir)
-
-	// Should contain "promptext"
-	assert.Contains(t, cacheDir, "promptext")
-
-	// Directory should be created
-	info, err := os.Stat(cacheDir)
-	require.NoError(t, err)
-	assert.True(t, info.IsDir())
-}
-
-// Integration test - requires network access
-func TestCheckForUpdate_Integration(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test in short mode")
-	}
-
-	// This test requires network access and should only run when explicitly requested
-	available, version, err := CheckForUpdate("v0.1.0")
-
-	// We expect this to find a newer version since v0.1.0 is very old
-	// If there's a network error, we skip the test rather than fail
+func writeZip(t *testing.T, fileName string, data []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	w, err := zw.Create(fileName)
 	if err != nil {
-		if err.Error() == "failed to fetch latest release: Get \"https://api.github.com/repos/1broseidon/promptext/releases/latest\": dial tcp: lookup api.github.com: no such host" {
-			t.Skip("Skipping integration test: no network access")
-		}
-		t.Logf("Warning: integration test failed with error: %v", err)
-		return
+		t.Fatalf("create zip file: %v", err)
 	}
-
-	assert.True(t, available, "Expected newer version to be available for v0.1.0")
-	assert.NotEmpty(t, version)
-	assert.Contains(t, version, "v", "Version should contain 'v' prefix")
-}
-
-func TestCheckAndNotifyUpdate_DevVersion(t *testing.T) {
-	// Should not panic or error for dev version
-	CheckAndNotifyUpdate("dev")
-	CheckAndNotifyUpdate("unknown")
-}
-
-func TestVersionComparison_EdgeCases(t *testing.T) {
-	tests := []struct {
-		v1   string
-		v2   string
-		want bool
-	}{
-		{"0.0.1", "0.0.0", true},
-		{"0.1.0", "0.0.99", true},
-		{"1.0.0", "0.99.99", true},
-		{"10.0.0", "9.99.99", true},
-		{"0.10.0", "0.9.0", true},
-		{"0.0.10", "0.0.9", true},
+	if _, err := w.Write(data); err != nil {
+		t.Fatalf("write zip data: %v", err)
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.v1+"_vs_"+tt.v2, func(t *testing.T) {
-			got, err := isNewerVersion(tt.v1, tt.v2)
-			require.NoError(t, err)
-			assert.Equal(t, tt.want, got)
-		})
+	if err := zw.Close(); err != nil {
+		t.Fatalf("close zip: %v", err)
 	}
+	return buf.Bytes()
 }
 
-// TestGetExecutablePath tests executable path resolution
-func TestGetExecutablePath(t *testing.T) {
-	path, err := getExecutablePath()
-	assert.NoError(t, err)
-	assert.NotEmpty(t, path)
-	
-	// Should be an absolute path
-	assert.True(t, filepath.IsAbs(path), "Executable path should be absolute")
+func sha256Hex(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
 }
 
-// TestFindReleaseAssets tests asset URL discovery
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stderr = w
+	fn()
+	w.Close()
+	os.Stderr = orig
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("copy stderr: %v", err)
+	}
+	return buf.String()
+}
+
 func TestFindReleaseAssets(t *testing.T) {
 	release := &ReleaseInfo{
-		TagName: "v0.5.0",
 		Assets: []struct {
 			Name               string `json:"name"`
 			BrowserDownloadURL string `json:"browser_download_url"`
 		}{
-			{
-				Name:               "promptext_Linux_x86_64.tar.gz",
-				BrowserDownloadURL: "https://example.com/promptext_Linux_x86_64.tar.gz",
-			},
-			{
-				Name:               "checksums.txt",
-				BrowserDownloadURL: "https://example.com/checksums.txt",
-			},
+			{Name: "promptext.tar.gz", BrowserDownloadURL: "http://example.com/asset"},
+			{Name: "checksums.txt", BrowserDownloadURL: "http://example.com/checksums"},
 		},
 	}
 
-	tests := []struct {
-		name      string
-		assetName string
-		wantErr   bool
-	}{
-		{
-			name:      "find Linux asset",
-			assetName: "promptext_Linux_x86_64.tar.gz",
-			wantErr:   false,
-		},
-		{
-			name:      "asset not found",
-			assetName: "nonexistent.tar.gz",
-			wantErr:   true,
-		},
+	downloadURL, checksumURL, err := findReleaseAssets(release, "promptext.tar.gz")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if downloadURL != "http://example.com/asset" || checksumURL != "http://example.com/checksums" {
+		t.Fatalf("unexpected urls: %s %s", downloadURL, checksumURL)
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			downloadURL, checksumURL, err := findReleaseAssets(release, tt.assetName)
-			if tt.wantErr {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-				assert.NotEmpty(t, downloadURL)
-				assert.NotEmpty(t, checksumURL)
-				assert.Contains(t, downloadURL, tt.assetName)
-			}
-		})
+	if _, _, err := findReleaseAssets(release, "missing"); err == nil {
+		t.Fatalf("expected error for missing asset")
 	}
 }
 
-// TestCopyFile tests file copying
-func TestCopyFile(t *testing.T) {
-	// Create a temporary source file
-	tmpDir, err := os.MkdirTemp("", "update-test-*")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
-
-	srcPath := filepath.Join(tmpDir, "source.txt")
-	dstPath := filepath.Join(tmpDir, "dest.txt")
-
-	testContent := "test file content for copy"
-	err = os.WriteFile(srcPath, []byte(testContent), 0644)
-	require.NoError(t, err)
-
-	// Test copy
-	err = copyFile(srcPath, dstPath)
-	assert.NoError(t, err)
-
-	// Verify destination exists and has same content
-	content, err := os.ReadFile(dstPath)
-	require.NoError(t, err)
-	assert.Equal(t, testContent, string(content))
-
-	// Test copying non-existent file
-	err = copyFile("/nonexistent/file.txt", dstPath)
-	assert.Error(t, err)
-}
-
-// TestVerifyChecksum tests checksum verification
-func TestVerifyChecksum(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "checksum-test-*")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
-
-	// Create a test file
-	testFile := filepath.Join(tmpDir, "test.bin")
-	testContent := []byte("test binary content")
-	err = os.WriteFile(testFile, testContent, 0644)
-	require.NoError(t, err)
-
-	// Calculate actual checksum (SHA256)
-	// For this test, we'll use a pre-calculated checksum
-	// echo -n "test binary content" | sha256sum
-	// Result: 56681959d2de970a2dbee51710bb02862bec0a603b725443b92063c02b5f0a0c
-
-	// Create checksums file
-	checksumFile := filepath.Join(tmpDir, "checksums.txt")
-	checksumContent := "56681959d2de970a2dbee51710bb02862bec0a603b725443b92063c02b5f0a0c  test.bin\n"
-	err = os.WriteFile(checksumFile, []byte(checksumContent), 0644)
-	require.NoError(t, err)
-
-	// Test valid checksum
-	err = verifyChecksum(testFile, checksumFile, "test.bin")
-	assert.NoError(t, err)
-
-	// Test with modified file (invalid checksum)
-	err = os.WriteFile(testFile, []byte("modified content"), 0644)
-	require.NoError(t, err)
-
-	err = verifyChecksum(testFile, checksumFile, "test.bin")
-	assert.Error(t, err, "Should fail with mismatched checksum")
-}
-
-// TestExtractTarGz tests tar.gz extraction
-func TestExtractTarGz(t *testing.T) {
-	t.Skip("Skipping tar.gz test - requires creating actual tar.gz archive")
-	// This would require creating a real tar.gz file which is complex
-	// The function is still tested via integration tests
-}
-
-// TestExtractZip tests zip extraction  
-func TestExtractZip(t *testing.T) {
-	t.Skip("Skipping zip test - requires creating actual zip archive")
-	// This would require creating a real zip file which is complex
-	// The function is still tested via integration tests
-}
-
-// TestExtractBinary tests binary extraction routing
-func TestExtractBinary(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "extract-test-*")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
-
-	tests := []struct {
-		name      string
-		archiveName string
-		shouldSkip bool
-	}{
-		{
-			name:       "tar.gz archive",
-			archiveName: "test.tar.gz",
-			shouldSkip: true, // Skip actual extraction
-		},
-		{
-			name:       "zip archive",
-			archiveName: "test.zip",
-			shouldSkip: true, // Skip actual extraction
-		},
-		{
-			name:       "unknown format",
-			archiveName: "test.unknown",
-			shouldSkip: false,
-		},
+func TestDownloadAndVerifyBinaryTarGz(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("tar.gz extraction not used on windows")
 	}
+	binaryData := []byte("test binary")
+	archiveBytes := writeTarGz(t, "promptext", binaryData)
+	checksum := sha256Hex(archiveBytes)
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if tt.shouldSkip {
-				t.Skip("Skipping extraction test - requires real archive")
-				return
-			}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/asset":
+			w.Write(archiveBytes)
+		case "/checksums.txt":
+			fmt.Fprintf(w, "%s  promptext.tar.gz\n", checksum)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
 
-			archivePath := filepath.Join(tmpDir, tt.archiveName)
-			_, err := extractBinary(archivePath, tmpDir)
-			assert.Error(t, err, "Unknown format should error")
-		})
+	path, err := downloadAndVerifyBinary(server.URL+"/asset", server.URL+"/checksums.txt", "promptext.tar.gz", false)
+	if err != nil {
+		t.Fatalf("downloadAndVerifyBinary failed: %v", err)
+	}
+	t.Cleanup(func() {
+		os.Remove(path)
+	})
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read binary: %v", err)
+	}
+	if !bytes.Equal(got, binaryData) {
+		t.Fatalf("unexpected binary contents: %q", got)
 	}
 }
 
-// TestLoadUpdateCache tests cache loading
-func TestLoadUpdateCache(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "cache-test-*")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
+func TestDownloadAndVerifyBinaryZip(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("zip extraction primarily for windows")
+	}
+	binaryData := []byte("zip binary")
+	archiveBytes := writeZip(t, "promptext.exe", binaryData)
+	checksum := sha256Hex(archiveBytes)
 
-	// Override cache dir for testing
-	cacheFile := filepath.Join(tmpDir, "update-check.json")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/asset":
+			w.Write(archiveBytes)
+		case "/checksums.txt":
+			fmt.Fprintf(w, "%s  promptext.zip\n", checksum)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
 
-	// Create a valid cache file
-	cache := &UpdateCheckCache{
-		LastCheck:     time.Now().Add(-1 * time.Hour),
-		LatestVersion: "0.5.0",
-		UpdateAvailable: true,
+	path, err := downloadAndVerifyBinary(server.URL+"/asset", server.URL+"/checksums.txt", "promptext.zip", false)
+	if err != nil {
+		t.Fatalf("downloadAndVerifyBinary failed: %v", err)
+	}
+	t.Cleanup(func() {
+		os.Remove(path)
+	})
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read binary: %v", err)
+	}
+	if !bytes.Equal(got, binaryData) {
+		t.Fatalf("unexpected binary contents: %q", got)
+	}
+}
+
+func TestDownloadAndVerifyBinaryChecksumMismatch(t *testing.T) {
+	binaryData := []byte("test binary")
+	archiveBytes := writeTarGz(t, "promptext", binaryData)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/asset":
+			w.Write(archiveBytes)
+		case "/checksums.txt":
+			fmt.Fprintf(w, "%s  promptext.tar.gz\n", strings.Repeat("0", 64))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	if _, err := downloadAndVerifyBinary(server.URL+"/asset", server.URL+"/checksums.txt", "promptext.tar.gz", false); err == nil {
+		t.Fatalf("expected checksum error")
+	}
+}
+
+func TestExtractBinaryUnsupported(t *testing.T) {
+	if _, err := extractBinary("file.bin", t.TempDir()); err == nil {
+		t.Fatalf("expected unsupported format error")
+	}
+}
+
+func TestCheckForUpdateWithTimeoutSuccess(t *testing.T) {
+	original := checkForUpdateFn
+	checkForUpdateFn = func(string) (bool, string, error) {
+		return true, "v1.2.3", nil
+	}
+	t.Cleanup(func() {
+		checkForUpdateFn = original
+	})
+
+	available, version, err := checkForUpdateWithTimeout("v1.0.0", time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !available || version != "v1.2.3" {
+		t.Fatalf("unexpected result: %v %s", available, version)
+	}
+}
+
+func TestCheckForUpdateWithTimeoutTimeout(t *testing.T) {
+	original := checkForUpdateFn
+	checkForUpdateFn = func(string) (bool, string, error) {
+		time.Sleep(20 * time.Millisecond)
+		return false, "", nil
+	}
+	t.Cleanup(func() {
+		checkForUpdateFn = original
+	})
+
+	if _, _, err := checkForUpdateWithTimeout("v1.0.0", time.Millisecond); err == nil {
+		t.Fatalf("expected timeout error")
+	}
+}
+
+func TestCheckForUpdateWithTimeoutError(t *testing.T) {
+	original := checkForUpdateFn
+	checkForUpdateFn = func(string) (bool, string, error) {
+		return false, "", errors.New("boom")
+	}
+	t.Cleanup(func() {
+		checkForUpdateFn = original
+	})
+
+	if _, _, err := checkForUpdateWithTimeout("v1.0.0", time.Second); err == nil {
+		t.Fatalf("expected propagated error")
+	}
+}
+
+func TestCheckAndNotifyUpdateUsesCache(t *testing.T) {
+	originalLoad := loadUpdateCacheFn
+	originalSave := saveUpdateCacheFn
+	originalCheck := checkForUpdateFn
+	defer func() {
+		loadUpdateCacheFn = originalLoad
+		saveUpdateCacheFn = originalSave
+		checkForUpdateFn = originalCheck
+	}()
+
+	loadUpdateCacheFn = func() (*UpdateCheckCache, error) {
+		return &UpdateCheckCache{
+			LastCheck:       time.Now(),
+			LatestVersion:   "v2.0.0",
+			UpdateAvailable: true,
+		}, nil
+	}
+	checkCalled := false
+	checkForUpdateFn = func(string) (bool, string, error) {
+		checkCalled = true
+		return false, "", nil
+	}
+	saveUpdateCacheFn = func(UpdateCheckCache) error {
+		return nil
 	}
 
-	data, err := json.Marshal(cache)
-	require.NoError(t, err)
-	err = os.WriteFile(cacheFile, data, 0644)
-	require.NoError(t, err)
+	output := captureStderr(t, func() {
+		CheckAndNotifyUpdate("v1.0.0")
+	})
 
-	// Note: loadUpdateCache() uses getCacheDir() internally
-	// We can't easily override it, so this tests the basic loading logic
+	if checkCalled {
+		t.Fatalf("expected cached result to avoid network call")
+	}
+	if !strings.Contains(output, "Update available: v2.0.0") {
+		t.Fatalf("expected notification, got %q", output)
+	}
+}
+
+func TestCheckAndNotifyUpdatePerformsCheckWhenStale(t *testing.T) {
+	originalLoad := loadUpdateCacheFn
+	originalSave := saveUpdateCacheFn
+	originalCheck := checkForUpdateFn
+	defer func() {
+		loadUpdateCacheFn = originalLoad
+		saveUpdateCacheFn = originalSave
+		checkForUpdateFn = originalCheck
+	}()
+
+	loadUpdateCacheFn = func() (*UpdateCheckCache, error) {
+		return &UpdateCheckCache{
+			LastCheck:       time.Now().Add(-2 * checkInterval),
+			LatestVersion:   "v1.0.0",
+			UpdateAvailable: false,
+		}, nil
+	}
+	var saved UpdateCheckCache
+	saveCalled := false
+	saveUpdateCacheFn = func(cache UpdateCheckCache) error {
+		saveCalled = true
+		saved = cache
+		return nil
+	}
+	checkForUpdateFn = func(string) (bool, string, error) {
+		return true, "v3.0.0", nil
+	}
+
+	output := captureStderr(t, func() {
+		CheckAndNotifyUpdate("v1.0.0")
+	})
+
+	if !saveCalled {
+		t.Fatalf("expected cache to be saved")
+	}
+	if saved.LatestVersion != "v3.0.0" || !saved.UpdateAvailable {
+		t.Fatalf("unexpected cache saved: %+v", saved)
+	}
+	if !strings.Contains(output, "Update available: v3.0.0") {
+		t.Fatalf("expected notification, got %q", output)
+	}
+}
+
+func TestReplaceBinaryRollback(t *testing.T) {
+	tmpDir := t.TempDir()
+	execPath := filepath.Join(tmpDir, "promptext")
+	backupPath := execPath + ".old"
+	if err := os.WriteFile(execPath, []byte("old"), 0755); err != nil {
+		t.Fatalf("write exec: %v", err)
+	}
+	newPath := filepath.Join(tmpDir, "new")
+	if err := os.WriteFile(newPath, []byte("new"), 0755); err != nil {
+		t.Fatalf("write new: %v", err)
+	}
+
+	originalCopy := copyFileFn
+	copyFileFn = func(string, string) error {
+		return errors.New("copy failed")
+	}
+	t.Cleanup(func() {
+		copyFileFn = originalCopy
+	})
+
+	if err := replaceBinary(execPath, newPath, false); err == nil {
+		t.Fatalf("expected replaceBinary to fail")
+	}
+	data, err := os.ReadFile(execPath)
+	if err != nil {
+		t.Fatalf("read exec: %v", err)
+	}
+	if string(data) != "old" {
+		t.Fatalf("expected original binary restored, got %q", data)
+	}
+	if _, err := os.Stat(backupPath); err == nil {
+		t.Fatalf("expected backup to be cleaned up")
+	}
+}
+
+func TestReplaceBinarySuccess(t *testing.T) {
+	tmpDir := t.TempDir()
+	execPath := filepath.Join(tmpDir, "promptext")
+	if err := os.WriteFile(execPath, []byte("old"), 0755); err != nil {
+		t.Fatalf("write exec: %v", err)
+	}
+	newPath := filepath.Join(tmpDir, "new")
+	if err := os.WriteFile(newPath, []byte("new"), 0755); err != nil {
+		t.Fatalf("write new: %v", err)
+	}
+
+	if err := replaceBinary(execPath, newPath, false); err != nil {
+		t.Fatalf("replaceBinary failed: %v", err)
+	}
+	data, err := os.ReadFile(execPath)
+	if err != nil {
+		t.Fatalf("read exec: %v", err)
+	}
+	if string(data) != "new" {
+		t.Fatalf("expected new binary installed, got %q", data)
+	}
+	if _, err := os.Stat(newPath); !os.IsNotExist(err) {
+		t.Fatalf("expected temporary binary to be removed")
+	}
+}
+
+func TestDownloadFileHTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	tmp := filepath.Join(t.TempDir(), "file")
+	if err := downloadFile(tmp, server.URL); err == nil {
+		t.Fatalf("expected download error")
+	}
+}
+
+func TestVerifyChecksumMissingEntry(t *testing.T) {
+	dir := t.TempDir()
+	archive := filepath.Join(dir, "archive")
+	if err := os.WriteFile(archive, []byte("data"), 0644); err != nil {
+		t.Fatalf("write archive: %v", err)
+	}
+	checksumPath := filepath.Join(dir, "checksums.txt")
+	if err := os.WriteFile(checksumPath, []byte("deadbeef  other.tar.gz\n"), 0644); err != nil {
+		t.Fatalf("write checksum: %v", err)
+	}
+
+	if err := verifyChecksum(archive, checksumPath, "promptext.tar.gz"); err == nil {
+		t.Fatalf("expected missing checksum error")
+	}
+}
+
+func TestVerifyChecksumMismatch(t *testing.T) {
+	dir := t.TempDir()
+	archive := filepath.Join(dir, "archive")
+	if err := os.WriteFile(archive, []byte("data"), 0644); err != nil {
+		t.Fatalf("write archive: %v", err)
+	}
+	checksumPath := filepath.Join(dir, "checksums.txt")
+	if err := os.WriteFile(checksumPath, []byte("deadbeef  archive\n"), 0644); err != nil {
+		t.Fatalf("write checksum: %v", err)
+	}
+
+	if err := verifyChecksum(archive, checksumPath, "archive"); err == nil {
+		t.Fatalf("expected mismatch error")
+	}
+}
+
+func TestLoadAndSaveUpdateCache(t *testing.T) {
+	dir := t.TempDir()
+	original := getCacheDirFn
+	getCacheDirFn = func() (string, error) {
+		return dir, nil
+	}
+	t.Cleanup(func() {
+		getCacheDirFn = original
+	})
+
+	cache := UpdateCheckCache{LatestVersion: "v1.0.0", UpdateAvailable: true, LastCheck: time.Unix(10, 0)}
+	if err := saveUpdateCache(cache); err != nil {
+		t.Fatalf("save cache: %v", err)
+	}
+
 	loaded, err := loadUpdateCache()
-	// May fail if cache dir doesn't exist, which is ok for this test
-	_ = loaded
-	_ = err
-}
-
-// TestReplaceBinary tests binary replacement logic
-func TestReplaceBinary(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "replace-test-*")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
-
-	// Create mock executable and new binary
-	execPath := filepath.Join(tmpDir, "old-binary")
-	newBinaryPath := filepath.Join(tmpDir, "new-binary")
-
-	err = os.WriteFile(execPath, []byte("old binary"), 0755)
-	require.NoError(t, err)
-	err = os.WriteFile(newBinaryPath, []byte("new binary"), 0755)
-	require.NoError(t, err)
-
-	// Test replacement (verbose = true for coverage)
-	err = replaceBinary(execPath, newBinaryPath, true)
-	assert.NoError(t, err)
-
-	// Verify the old binary was replaced
-	content, err := os.ReadFile(execPath)
-	require.NoError(t, err)
-	assert.Equal(t, "new binary", string(content))
-}
-
-// TestCheckForUpdateWithTimeout tests timeout behavior
-func TestCheckForUpdateWithTimeout(t *testing.T) {
-	// Test with very short timeout - should timeout
-	available, version, err := checkForUpdateWithTimeout("0.1.0", 1*time.Nanosecond)
-	
-	// Either timeout error or success (if network is very fast)
-	_ = available
-	_ = version
-	_ = err
-	// This test is informational - network behavior varies
+	if err != nil {
+		t.Fatalf("load cache: %v", err)
+	}
+	if loaded.LatestVersion != cache.LatestVersion || loaded.UpdateAvailable != cache.UpdateAvailable {
+		t.Fatalf("unexpected cache contents: %+v", loaded)
+	}
 }


### PR DESCRIPTION
## Summary
- refactor the promptext CLI into an injectable `run` helper to enable fine-grained testing of flag parsing and dispatch
- add comprehensive CLI unit tests covering update checks, initialization, format detection, and notification paths
- introduce function indirection and extensive tests for the updater, token counter, and PTX/JSONL formatters to raise coverage

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_690c47a46b608320923cb613a8b46a2b